### PR TITLE
showHelp when `args` is empty

### DIFF
--- a/src/command_parser.ts
+++ b/src/command_parser.ts
@@ -131,10 +131,6 @@ export class CommandParser {
 
   parse(args?: string[]): void {
     const validArgs = args ?? process.argv.slice(2);
-    if (validArgs.length === 0) {
-      return this.showHelp();
-    }
-
     const commands = this._commands.map((command) => {
       return command._toParseCommand();
     });
@@ -299,6 +295,10 @@ export class CommandParser {
     | ParseResultVersion
     | ParseResultMatch<object> {
     try {
+      if (args.length === 0) {
+        throw new ParseError("No command specified");
+      }
+      
       const parsed = parseMultipleCommands({
         args,
         commands,

--- a/src/command_parser.ts
+++ b/src/command_parser.ts
@@ -131,6 +131,7 @@ export class CommandParser {
 
   parse(args?: string[]): void {
     const validArgs = args ?? process.argv.slice(2);
+
     const commands = this._commands.map((command) => {
       return command._toParseCommand();
     });

--- a/src/command_parser.ts
+++ b/src/command_parser.ts
@@ -131,6 +131,9 @@ export class CommandParser {
 
   parse(args?: string[]): void {
     const validArgs = args ?? process.argv.slice(2);
+    if (args.length === 0) {
+      return this.showHelp();
+    }
 
     const commands = this._commands.map((command) => {
       return command._toParseCommand();

--- a/src/command_parser.ts
+++ b/src/command_parser.ts
@@ -131,7 +131,7 @@ export class CommandParser {
 
   parse(args?: string[]): void {
     const validArgs = args ?? process.argv.slice(2);
-    if (args.length === 0) {
+    if (validArgs.length === 0) {
       return this.showHelp();
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved command parsing to display help when no arguments are provided.
	- Added a validation step for the presence of a command in the input arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->