### PR TITLE
[bug report] Add failing test for array options with default

### DIFF
--- a/test/parser.parse.test.ts
+++ b/test/parser.parse.test.ts
@@ -887,6 +887,20 @@ describe("type", () => {
         }>();
       });
 
+      test("default(['default']) with arg", () => {
+        const parsed = parser()
+          .options({
+            opt: {
+              type: z.array(z.string()).default(["default1", "default2"]),
+            },
+          })
+          .parse(["--opt", "str1"]);
+        expect(parsed).toEqual({ opt: ["str1"] });
+        expectTypeOf(parsed).toEqualTypeOf<{
+          opt: string[];
+        }>();
+      });
+
       test("when splitted", () => {
         const parsed = parser()
           .options({


### PR DESCRIPTION
(This is not a PR for merging, just a bug report.)

It seems that using `z.array(...).default(...)` doesn't allow setting the defined option. As demonstrated by the added failing test. Note that there's a similar test-case before for the same type of option, just without passing in any arguments.

Or am I misunderstanding how to use the api or pass in array arguments?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Added a test to ensure the parser correctly prioritizes user-provided arguments over default settings, resulting in consistent output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->