### PR TITLE
Add more tests and refactor duplicated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ const schema = z.string().default("foo").optional();
 // Zod v4: schema.parse(undefined) → "foo"
 ```
 
-| Pattern | Zod v3 | Zod v4 |
-|---------|--------|--------|
-| `z.string().optional()` | `undefined` | `undefined` |
-| `z.string().default("foo")` | `"foo"` | `"foo"` |
-| `z.string().optional().default("foo")` | `"foo"` | `"foo"` |
-| `z.string().default("foo").optional()` | `undefined` | `"foo"` |
+| Pattern                                | Zod v3      | Zod v4      |
+| -------------------------------------- | ----------- | ----------- |
+| `z.string().optional()`                | `undefined` | `undefined` |
+| `z.string().default("foo")`            | `"foo"`     | `"foo"`     |
+| `z.string().optional().default("foo")` | `"foo"`     | `"foo"`     |
+| `z.string().default("foo").optional()` | `undefined` | `"foo"`     |
 
 In Zod v4, `.default()` always applies regardless of `.optional()`. If you're migrating from v3 to v4, review any usage of `.default().optional()` as the behavior has changed.
 

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -11,7 +11,7 @@ interface MaybeZod extends Record<string, unknown> {
   parse?: unknown;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 

--- a/src/zod_util.ts
+++ b/src/zod_util.ts
@@ -1,6 +1,12 @@
 import type { ZodTypeAny } from "zod";
 
-import { getDef, getDescription, isZodSchema, type SchemaDef } from "./compat";
+import {
+  getDef,
+  getDescription,
+  isRecord,
+  isZodSchema,
+  type SchemaDef,
+} from "./compat";
 import type {
   BaseType,
   BaseTypeT,
@@ -11,10 +17,6 @@ import type {
 } from "./type";
 import { BASE_TYPES } from "./type";
 import { uniq } from "./util";
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 const TYPE_NAME_MAP: Record<string, string> = {
   ZodString: "string",

--- a/test/parser_helper.test.ts
+++ b/test/parser_helper.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "@jest/globals";
+import { z } from "zod";
+
+import { generateZodShape } from "../src/parser_helper";
+
+describe("generateZodShape()", () => {
+  test("common", () => {
+    const result = generateZodShape(
+      {
+        opt1: { type: z.string() },
+      },
+      [{ name: "pos1", type: z.string() }]
+    );
+    expect(result).toHaveProperty("opt1");
+    expect(result).toHaveProperty("pos1");
+  });
+
+  test("returns empty shape when options and positionalArgs are undefined", () => {
+    expect(generateZodShape()).toEqual({});
+  });
+});

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, jest, test } from "@jest/globals";
+
+import {
+  findDuplicateValues,
+  validateParamOptionsAndPositionalArguments,
+} from "../src/util";
+
+describe("util validation", () => {
+  test("findDuplicateValues returns duplicates", () => {
+    expect(findDuplicateValues(["a", "b", "a", "c", "b"])).toEqual(["a", "b"]);
+  });
+
+  test("throws on duplicate option names", () => {
+    const keySpy = jest.spyOn(Object, "keys").mockReturnValue(["opt1", "opt1"]);
+    try {
+      validateParamOptionsAndPositionalArguments(
+        { opt1: { type: "string" as const } },
+        []
+      );
+      throw new Error("expected duplicate option error");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (!message.includes("Duplicated option name")) {
+        throw err;
+      }
+    } finally {
+      keySpy.mockRestore();
+    }
+  });
+
+  test("throws on duplicate positional names", () => {
+    expect(() => {
+      validateParamOptionsAndPositionalArguments({}, [
+        { name: "pos1", type: "string" as const },
+        { name: "pos1", type: "string" as const },
+      ]);
+    }).toThrow(/Duplicated positional argument name/);
+  });
+
+  test("throws when option and positional share name", () => {
+    expect(() => {
+      validateParamOptionsAndPositionalArguments(
+        { shared: { type: "string" as const } },
+        [{ name: "shared", type: "string" as const }]
+      );
+    }).toThrow(/Duplicated option name with positional argument name/);
+  });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for `generateZodShape()` and validation utilities
- Refactor duplicated `isRecord()` function by exporting from `compat.ts`
- Fix README table formatting

## Changes
- **test/parser_helper.test.ts**: Added tests for `generateZodShape()` function
- **test/util.test.ts**: Added tests for validation functions (`findDuplicateValues`, `validateParamOptionsAndPositionalArguments`)
- **src/compat.ts**: Export `isRecord()` function to reduce duplication
- **src/zod_util.ts**: Remove duplicated `isRecord()` function, import from `compat.ts` instead
- **README.md**: Format comparison table for better readability

## Test plan
- Run `npm test` to verify all tests pass
- Verify test coverage improvements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Zod v3/v4 compatibility guidance with clearer recommendations for using `.default()` and `.optional()`
  * Improved table formatting, accuracy, and expanded compatibility notes

* **Tests**
  * Added test coverage for parser helper and utility validation functions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->