### PR TITLE
Add regression tests for array options with default values

### DIFF
--- a/test/parser.parse.test.ts
+++ b/test/parser.parse.test.ts
@@ -879,6 +879,20 @@ describe("type", () => {
         }>();
       });
 
+      test("default(['default']) with arg", () => {
+        const parsed = parser()
+          .options({
+            opt: {
+              type: z.array(z.string()).default(["default1", "default2"]),
+            },
+          })
+          .parse(["--opt", "str1"]);
+        expect(parsed).toEqual({ opt: ["str1"] });
+        expectTypeOf(parsed).toEqualTypeOf<{
+          opt: string[];
+        }>();
+      });
+
       test("when splitted", () => {
         const parsed = parser()
           .options({
@@ -1026,6 +1040,21 @@ describe("type", () => {
           ])
           .parse([]);
         expect(parsed).toEqual({ pos: ["default1", "default2"] });
+        expectTypeOf(parsed).toEqualTypeOf<{
+          pos: string[];
+        }>();
+      });
+
+      test("default(['default']) with arg", () => {
+        const parsed = parser()
+          .args([
+            {
+              name: "pos",
+              type: z.array(z.string()).default(["default1", "default2"]),
+            },
+          ])
+          .parse(["str1"]);
+        expect(parsed).toEqual({ pos: ["str1"] });
         expectTypeOf(parsed).toEqualTypeOf<{
           pos: string[];
         }>();


### PR DESCRIPTION
## Summary
- Add regression tests for array options with default values to ensure that when an argument is provided, it properly overrides the default value
- Added test cases for both `options` and `args` configurations

## Test plan
- [x] New tests added and passing
- [x] Tests verify that default array values are correctly overridden when arguments are provided

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for default value behavior when explicit arguments are provided, ensuring correct type inference across different parameter configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->